### PR TITLE
[#18] Strip trailing OR from search query

### DIFF
--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -5,6 +5,16 @@
 # See http://stackoverflow.com/questions/7072758/plugin-not-reloading-in-development-mode
 #
 Rails.configuration.to_prepare do
+
+  # Temporary fix to prevent daily exception notification
+  TrackController.class_eval do
+    before_filter :strip_trailing_or, :only => [:track_search_query]
+
+    def strip_trailing_or
+      params[:query_array] = params[:query_array].sub(/\sOR\z/, '')
+    end
+  end
+
   HelpController.class_eval do
     def downloads ; end
 

--- a/spec/controllers/controller_patches_spec.rb
+++ b/spec/controllers/controller_patches_spec.rb
@@ -2,6 +2,29 @@
 ALAVETELI_TEST_THEME = 'askyourgovug-theme'
 require File.expand_path(File.join(File.dirname(__FILE__),'..','..','..','..', '..', 'spec','spec_helper'))
 
+describe TrackController do
+
+  it 'strips a trailing OR from a search query' do
+    get :track_search_query,
+        :feed => 'feed',
+        :query_array => " (latest_status:waiting_response OR " \
+                        "latest_status:waiting_clarification OR " \
+                        "waiting_classification:true OR " \
+                        "latest_status:internal_review OR " \
+                        "latest_status:gone_postal OR " \
+                        "latest_status:error_message OR"
+
+    expected = " (latest_status:waiting_response OR " \
+               "latest_status:waiting_clarification OR " \
+               "waiting_classification:true OR " \
+               "latest_status:internal_review OR " \
+               "latest_status:gone_postal OR " \
+               "latest_status:error_message"
+    expect(assigns[:query]).to eq(expected)
+  end
+
+end
+
 describe HelpController do
 
   context "when overriden by the theme" do


### PR DESCRIPTION
Temporary fix for #18.

We get a more-or-less daily error from someone making this search, so
this fixes that specific issue until we fix it in Alaveteli core [1].

If you paste the query array in to the search box the malformed query
error gets handled…

    Your query was not quite right. QueryParserError: Syntax:
    <expression> OR <expression>

…so that's probably the place to start looking for a permanent fix.

[1] https://github.com/mysociety/alaveteli/issues/2919